### PR TITLE
metadata: Don't set "version" field

### DIFF
--- a/custom-menu-panel@AndreaBenini/metadata.json
+++ b/custom-menu-panel@AndreaBenini/metadata.json
@@ -5,6 +5,5 @@
     "40", "41", "42", "43", "44"
   ],
   "url": "https://github.com/andreabenini/gnome-plugin.custom-menu-panel",
-  "uuid": "custom-menu-panel@AndreaBenini",
-  "version": 4
+  "uuid": "custom-menu-panel@AndreaBenini"
 }


### PR DESCRIPTION
It is automatically set by extensions.gnome.org on upload.

If a custom version is desired, newer versions support an author-provided "version-name" field.